### PR TITLE
Actualiza .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,12 @@
 *.exe
 *.out
 *.app
+
+# Project specific
+*Makefile.depends
+nachos
+nachos/code/bin/readnoff
+nachos/code/bin/coff2flat
+nachos/code/bin/coff2noff
+nachos/code/bin/disassemble
+!nachos/


### PR DESCRIPTION
Permite ignorar:
- Makefile.depends
- Ejecutables nachos
- Otros binarios generados (readnoff, coff2flat, coff2noff, disassemble)